### PR TITLE
use exec so the command also receives unix signals

### DIFF
--- a/util/docker/entrypoint.sh
+++ b/util/docker/entrypoint.sh
@@ -16,5 +16,5 @@ echo "Welcome to Containernet running within a Docker container ..."
 if [[ $# -eq 0 ]]; then
     exec /bin/bash
 else
-    $*
+    exec $*
 fi


### PR DESCRIPTION
can be handy in case containernet is started in container itself.
the started command will have PID=0 and recieve the SIGTERM signal sent by docker stop.